### PR TITLE
Changed the selection background color for the gutter

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -47,7 +47,7 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
 
       &.cursor-line {
         color: @syntax-gutter-text-color-selected;
-        background-color: @syntax-gutter-background-color-selected;
+        background-color: @syntax-selection-color;
       }
       &.cursor-line-no-selection {
         background-color: transparent;


### PR DESCRIPTION
The line numbers were barely readable when a line was selected since it was given a dark blue background, I changed it to be the same as the selected text to improve readability
